### PR TITLE
Specify file encoding

### DIFF
--- a/guesser.py
+++ b/guesser.py
@@ -7,7 +7,7 @@ from state import State
 
 class Guesser:
     def __init__(self,  path_to_words: str):
-        with open(path_to_words, 'r') as f:
+        with open(path_to_words, 'r',  encoding='utf-8') as f:
             self.words_from_path = list(map(str.strip, f.read().split()))
         self.letters_freq = collections.Counter(''.join(self.words_from_path))
 

--- a/state.py
+++ b/state.py
@@ -35,7 +35,7 @@ class State:
 
     @classmethod
     def from_file(cls, path: str):
-        with open(path, 'r') as f:
+        with open(path, 'r',  encoding='utf-8') as f:
             lines = f.readlines()
             words = map(lambda x: zip(*x), map(str.split, lines))
             parsed_words = []


### PR DESCRIPTION
Before my changes there was such error on windows:
```
C:\Users\nikitosing\Downloads\wordle-solver>python main.py --words ./rus-words-5.txt --state ./state
Traceback (most recent call last):
  File "C:\Users\nikitosing\Downloads\wordle-solver\main.py", line 12, in <module>
    options = one_guess(args.words, args.state)
  File "C:\Users\nikitosing\Downloads\wordle-solver\guesser.py", line 24, in one_guess
    state = State.from_file(path_to_state)
  File "C:\Users\nikitosing\Downloads\wordle-solver\state.py", line 39, in from_file
    lines = f.readlines()
  File "C:\Users\nikitosing\AppData\Local\Programs\Python\Python39\lib\encodings\cp1251.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 79: character maps to <undefined>
```